### PR TITLE
list.get() should return the first element

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,7 +233,7 @@ List.prototype.last = function(){
  */
 
 List.prototype.get = function(i){
-  return this.els[i];
+  return this.els[i || 0];
 };
 
 /**

--- a/test/dom.js
+++ b/test/dom.js
@@ -111,6 +111,10 @@ describe('.get(i)', function(){
     var list = dom('<em>Hello</em>');
     assert('Hello' == list.get(0).textContent);
   })
+  it('should return the first element if index is not specified', function () {
+    var list = dom('<em>Hello</em>');
+    assert('Hello' == list.get().textContent);
+  })
 })
 
 describe('.at(i)', function(){


### PR DESCRIPTION
Sometimes it's evident that there is only one element in the list. For such cases I think `.get()` is better than `.get(0)`. E.g. `list.first().get()`
