### PR TITLE
Fix: Domify returns a fragment and not an array 

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function dom(selector, context) {
 
   // html
   if ('<' == selector.charAt(0)) {
-    return new List([domify(selector)[0]], selector);
+    return new List([domify(selector)], selector);
   }
 
   // selector


### PR DESCRIPTION
Since this [commit](https://github.com/component/domify/commit/1c18f7695f580afd3f4cc429dbbbe5c09c9a9449), domify returns a fragment and not an array.
