### PR TITLE
fixed .html() test

### DIFF
--- a/test/dom.js
+++ b/test/dom.js
@@ -122,7 +122,7 @@ describe('.length()', function(){
 
 describe('.html()', function(){
   it('should return an html string', function(){
-    var a = dom('<p>Hello <em>World</em><p>');
+    var a = dom('<p>Hello <em>World</em></p>');
     assert('Hello <em>World</em>' == a.html());
   })
 })


### PR DESCRIPTION
The .html() unit test is failing because of a tiny mistake in the html syntax.
