### PR TITLE
Fix insertAfter on a NodeList

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ List.prototype.appendTo = function(val){
 List.prototype.insertAfter = function(val){
   val = dom(val).els[0];
   if (!val || !val.parentNode) return this;
-  this.els.forEach(function(el){
+  this.forEach(function(el){
     val.parentNode.insertBefore(el, val.nextSibling);
   });
   return this;


### PR DESCRIPTION
This was depending on els having a forEach method. This is not the case if List was created from a NodeList.
