### PR TITLE
correcting .html() test case

### DIFF
--- a/test/dom.js
+++ b/test/dom.js
@@ -139,7 +139,7 @@ describe('.length()', function(){
 
 describe('.html()', function(){
   it('should return an html string', function(){
-    var a = dom('<p>Hello <em>World</em><p>');
+    var a = dom('<p>Hello <em>World</em></p>');
     assert('Hello <em>World</em>' == a.html());
   })
 })


### PR DESCRIPTION
The opening paragraph tag wasn't being closed - assuming it's simply a typo.  I haven't spent the time to determine what caused the break or how long it's been broken.
