### PR TITLE
Remove element clone from .replace()

### DIFF
--- a/index.js
+++ b/index.js
@@ -321,7 +321,7 @@ List.prototype.replace = function(val){
   for (var i = 0; i < this.els.length; i++) {
     var old = this.els[i];
     var parent = old.parentNode;
-    if (parent) parent.replaceChild(el.cloneNode(true), old);
+    if (parent) parent.replaceChild(el, old);
   }
   return val;
 };


### PR DESCRIPTION
If a `List` or an `Element` is provided as `val`, then I'd like to keep manipulating it and affect the `DOM`.
More here: https://github.com/component/dom/commit/ab8b1cf8bbbe69a4c039e0d1fd43d0fe0b9986da#commitcomment-4608874
