### PR TITLE
fix undefined dom in .reject()

### DIFF
--- a/lib/traverse.js
+++ b/lib/traverse.js
@@ -210,6 +210,7 @@ exports.select = function(fn){
  */
 
 exports.reject = function(fn){
+  var dom = this.dom;
   var out = [];
   var len = this.length;
   var val, i;


### PR DESCRIPTION
`dom` was undefined at lib/traverse.js:222.
