### PR TITLE
Update matthewp/keys

### DIFF
--- a/component.json
+++ b/component.json
@@ -30,7 +30,7 @@
     "component/trim": "0.0.1",
     "yields/isArray": "1.0.0",
     "component/to-function": "2.0.0",
-    "matthewp/keys": "0.0.2",
+    "matthewp/keys": "0.0.3",
     "matthewp/text": "0.0.2"
   },
   "development": {


### PR DESCRIPTION
Its 0.0.2 tag has a mismatched version number.

Bumping it to 0.0.3 allows me to install this with component-shrinkwrap(1). :)
