### PR TITLE
Replace yields/isArray with KenanY/is-array

### DIFF
--- a/component.json
+++ b/component.json
@@ -28,7 +28,7 @@
     "component/matches-selector": "0.1.1",
     "yields/traverse": "0.1.1",
     "component/trim": "0.0.1",
-    "yields/isArray": "1.0.0",
+    "KenanY/is-array": "1.0.1",
     "component/to-function": "2.0.0",
     "matthewp/keys": "0.0.3",
     "matthewp/text": "0.0.2"

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var isArray = require('isArray');
+var isArray = require('is-array');
 var domify = require('domify');
 var each = require('each');
 var events = require('event');


### PR DESCRIPTION
yields/isArray unfortunately does not follow the new spec, which requires that component names be lowercase.

This pull request replaces yields/isArray with KenanY/is-array, which is Lo-Dash's `_.isArray` but rewritten for `component(1)`. Lo-Dash is pretty well-known for supporting many browsers so I trust that this change shouldn't break current browser compatibility. Some results from testling are available [here](https://ci.testling.com/KenanY/is-array) but it's really slow and some browsers were never even reached :(
